### PR TITLE
[patch] use icu data from prebuild binary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,6 @@ ENV VERSION=v12.13.1  NPM_VERSION=6 YARN_VERSION=latest
 # For base builds
 # ENV CONFIG_FLAGS="--without-npm" RM_DIRS=/usr/include
 # ENV CONFIG_FLAGS="--fully-static --without-npm" DEL_PKGS="libgcc libstdc++" RM_DIRS=/usr/include
-# For Intl builds uncomment
-ENV CONFIG_FLAGS="--with-intl=full-icu --download=all"
 
 RUN apk add --no-cache curl make gcc g++ python linux-headers binutils-gold gnupg libstdc++ && \
   for server in ipv4.pool.sks-keyservers.net keyserver.pgp.com ha.pool.sks-keyservers.net; do \
@@ -56,9 +54,12 @@ RUN apk add --no-cache curl make gcc g++ python linux-headers binutils-gold gnup
       rm ${YARN_VERSION}.tar.gz*; \
     fi; \
   fi && \
+  npm install --unsafe-perm -g full-icu && \
   apk del curl make gcc g++ python linux-headers binutils-gold gnupg ${DEL_PKGS} && \
   rm -rf ${RM_DIRS} /node-${VERSION}* /SHASUMS256.txt /tmp/* /var/cache/apk/* \
     /usr/share/man/* /usr/share/doc /root/.npm /root/.node-gyp /root/.config \
     /usr/lib/node_modules/npm/man /usr/lib/node_modules/npm/doc /usr/lib/node_modules/npm/docs \
     /usr/lib/node_modules/npm/html /usr/lib/node_modules/npm/scripts && \
   { rm -rf /root/.gnupg || true; }
+
+ENV NODE_ICU_DATA /usr/lib/node_modules/full-icu


### PR DESCRIPTION
Note: this merges to the `intl` branch.

Use https://github.com/unicode-org/full-icu-npm to grab prebuild binary and pass data to node as  runtime rather than prebuild. For some very unclear reason `--with-intl=full-icu --download=all` keeps failing, see image:

_![image](https://user-images.githubusercontent.com/670951/75048916-98fb7f00-54c9-11ea-8142-110b89e84f31.png)_

This will use a runtime feature in node (which already has small-icu) https://nodejs.org/api/intl.html#intl_providing_icu_data_at_runtime. Since `full-icu` will be baked in with `nodejs>13` https://github.com/nodejs/node/pull/29522 this alternative 'fix' is good enough for our `node@12` usage.

Validation that it works (Spanish for January)

<img width="548" alt="image" src="https://user-images.githubusercontent.com/670951/75048881-8aad6300-54c9-11ea-858c-9c068a1e500d.png">
